### PR TITLE
Fixed renderer issue, added run command for manage.

### DIFF
--- a/core/management/commands/run.py
+++ b/core/management/commands/run.py
@@ -1,0 +1,9 @@
+from django.core.management.commands.runserver import Command as RunServer
+
+class Command(RunServer):
+
+    def check(self, *args, **kwargs):
+        self.stdout.write(self.style.WARNING("SKIPPING SYSTEM CHECKS!\n"))
+
+    def check_migrations(self, *args, **kwargs):
+        self.stdout.write(self.style.WARNING("SKIPPING MIGRATION CHECKS!\n"))

--- a/core/views.py
+++ b/core/views.py
@@ -26,6 +26,7 @@ class SupawordAPIView(generics.CreateAPIView):
         """
         super().__init__()
         self.request_handler = request_handler
+        self.http_method_names = ['post']
 
     def get_serializer_context(self):
         """
@@ -90,14 +91,6 @@ class SupawordAPIView(generics.CreateAPIView):
             return self._post(request, *args, **kwargs)
         else:
             return self._post_protected(request, *args, **kwargs)
-
-    def dispatch(self, request, *args, **kwargs):
-        """
-        Check request type and allow only POST
-        """
-        if request.method != 'POST':
-            return Response({'error': 'Invalid access method'}, status=status.HTTP_400_BAD_REQUEST)
-        return super().dispatch(request, *args, **kwargs)
 
 
 class PeopleExtendedAPIView(SupawordAPIView):
@@ -253,14 +246,6 @@ class OrganizationsAPIView(SupawordAPIView):
         organizations_serializer = OrganizationSerializer(organizations, many=True)
 
         return Response(data=organizations_serializer.data, headers={'Server-Version': settings.VERSION})
-
-    def dispatch(self, request, *args, **kwargs):
-        """
-        Check request type and allow only POST
-        """
-        if request.method != 'POST':
-            return Response({'error': 'Invalid access method'}, status=status.HTTP_400_BAD_REQUEST)
-        return super().dispatch(request, *args, **kwargs)
 
 
 def bad_request(request):


### PR DESCRIPTION
Django initializes `rest_framework.Request` in order to render `rest_framework.Response` 
This makes it impossible to render `Response` directly from `dispatch` method - it has no idea about which way it should be rendered.

Also added command for `python manage.py run` to enable continuous development with auto-reload.